### PR TITLE
ci: freeze v1 Cloud Run deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,16 @@
 # ============================================================
-# VIPL Email Agent — CI/CD Pipeline
+# VIPL Email Agent v1 — CI/CD Pipeline (FROZEN)
 # ============================================================
-# Single workflow for test, deploy, and release.
+# DEPLOY FREEZE: v1 deployments are frozen while v2 is in
+# development. Remove this freeze after v2 migration is complete
+# and Cloud Run is decommissioned.
 #
-# Triggers:
-#   - Version tags (v*.*.*): test → deploy → release
-#   - Pull requests: test only (no deploy)
-#
-# Auth: Workload Identity Federation (no SA key stored in GitHub)
+# v2 deployment pipeline lives on the v2 branch.
 # ============================================================
 
-name: Deploy & Release
+name: Deploy & Release (v1 - FROZEN)
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Removes version tag trigger from v1 deploy.yml to prevent accidental Cloud Run deployments
- v2 development is active on the `v2` branch with its own VM-based deploy pipeline
- PR tests still run on main branch PRs

## Why
v2 is in active development. Any accidental `v*.*.*` tag push would trigger a Cloud Run deploy with potentially broken code. This freeze stays until v2 migration is complete and Cloud Run is decommissioned (Phase 6).

## Revert
Re-add the tag trigger after v2 cutover in Phase 6.

## Test plan
- [ ] Verify no deploy triggers on tag push to main
- [ ] Verify PR tests still run on main PRs

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)