### PR TITLE
fix: deploy.yml secrets in if-conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,14 +42,16 @@ jobs:
     name: Deploy to VM
     needs: test
     runs-on: ubuntu-latest
+    env:
+      CHAT_WEBHOOK: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Notify Chat — deploying
-        if: secrets.GOOGLE_CHAT_WEBHOOK_URL != ''
+        if: env.CHAT_WEBHOOK != ''
         run: |
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST "$CHAT_WEBHOOK" \
             -H 'Content-Type: application/json' \
             -d '{"text": "🚀 *Deploying ${{ github.event.release.tag_name }}* to triage.vidarbhainfotech.com …"}'
 
@@ -72,16 +74,16 @@ jobs:
             echo "Deployed ${{ github.event.release.tag_name }}"
 
       - name: Notify Chat — deployed
-        if: success() && secrets.GOOGLE_CHAT_WEBHOOK_URL != ''
+        if: success() && env.CHAT_WEBHOOK != ''
         run: |
           BODY=$(echo '${{ github.event.release.body }}' | head -c 500 | sed 's/"/\\"/g' | tr '\n' ' ')
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST "$CHAT_WEBHOOK" \
             -H 'Content-Type: application/json' \
             -d "{\"text\": \"✅ *${{ github.event.release.tag_name }}* deployed successfully\\n\\n${BODY}\"}"
 
       - name: Notify Chat — deploy failed
-        if: failure() && secrets.GOOGLE_CHAT_WEBHOOK_URL != ''
+        if: failure() && env.CHAT_WEBHOOK != ''
         run: |
-          curl -s -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          curl -s -X POST "$CHAT_WEBHOOK" \
             -H 'Content-Type: application/json' \
             -d '{"text": "❌ *Deploy ${{ github.event.release.tag_name }} FAILED* — check https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'


### PR DESCRIPTION
## Summary
- `secrets.*` cannot be used directly in `if:` expressions in GitHub Actions
- Move webhook URL to job-level `env` var and reference `env.CHAT_WEBHOOK` in conditions

## Test plan
- [x] Workflow file validates (no more "Unrecognized named-value: secrets" error)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)