### PR TITLE
fix: v2.8.2 bug fixes & code quality

### DIFF
--- a/apps/emails/services/ai_processor.py
+++ b/apps/emails/services/ai_processor.py
@@ -136,7 +136,7 @@ def _get_team_workload() -> list:
             })
         return result
     except Exception:
-        logger.debug("Could not fetch team workload (expected in tests without DB)")
+        logger.warning("Could not fetch team workload", exc_info=True)
         return []
 
 
@@ -209,13 +209,23 @@ class AIProcessor:
 
             correction_rules = SystemConfig.get("correction_rules", "")
             if correction_rules and correction_rules != "No correction rules yet.":
-                raw_prompt += (
-                    "\n\n<correction_rules>\n"
-                    "The following rules are based on past corrections by the team. "
-                    "Follow these when making assignment suggestions:\n"
-                    f"{correction_rules}\n"
-                    "</correction_rules>"
-                )
+                # Sanitize: strip XML/HTML tags and limit length to prevent prompt injection
+                sanitized_rules = re.sub(r'<[^>]+>', '', correction_rules)
+                sanitized_rules = sanitized_rules[:2000]
+                # Prefix each line with "- " delimiter for safe injection
+                rule_lines = [
+                    f"- {line.strip()}"
+                    for line in sanitized_rules.split("\n")
+                    if line.strip()
+                ]
+                if rule_lines:
+                    raw_prompt += (
+                        "\n\n<correction_rules>\n"
+                        "The following rules are based on past corrections by the team. "
+                        "Follow these when making assignment suggestions:\n"
+                        + "\n".join(rule_lines) + "\n"
+                        "</correction_rules>"
+                    )
         except Exception:
             logger.debug("Could not load correction rules (expected in tests without DB)")
 

--- a/apps/emails/services/gmail_poller.py
+++ b/apps/emails/services/gmail_poller.py
@@ -28,6 +28,9 @@ from .dtos import EmailMessage
 
 logger = logging.getLogger(__name__)
 
+# Number of emails to fetch on the first poll per inbox
+FIRST_POLL_LIMIT = 5
+
 SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.labels",
@@ -293,7 +296,7 @@ class GmailPoller:
 
         if not self._first_poll_done:
             query = "in:inbox"
-            max_results = 5
+            max_results = FIRST_POLL_LIMIT
             logger.info(f"First poll for {inbox_email}: fetching latest {max_results} emails")
         else:
             query = f"in:inbox after:{self._start_epoch} -label:{self.processed_label}"

--- a/apps/emails/services/pipeline.py
+++ b/apps/emails/services/pipeline.py
@@ -13,7 +13,7 @@ import time
 from datetime import timedelta
 from typing import Optional
 
-from django.db import close_old_connections
+from django.db import close_old_connections, transaction
 
 from django.db import models as db_models
 
@@ -184,119 +184,120 @@ def save_email_to_db(email_msg: EmailMessage, triage: TriageResult) -> Email:
     Uses update_or_create with message_id as lookup key for dedup.
     Also saves AttachmentMetadata for each attachment.
     """
-    email_obj, created = Email.objects.update_or_create(
-        message_id=email_msg.message_id,
-        defaults={
-            "gmail_id": email_msg.message_id,
-            "gmail_thread_id": email_msg.thread_id,
-            "from_address": email_msg.sender_email,
-            "from_name": email_msg.sender_name,
-            "to_inbox": email_msg.inbox,
-            "subject": email_msg.subject,
-            "body": email_msg.body,
-            "body_html": email_msg.body_html,
-            "headers": email_msg.headers,
-            "received_at": email_msg.timestamp,
-            "gmail_link": email_msg.gmail_link,
-            # AI triage fields
-            "category": triage.category,
-            "priority": triage.priority,
-            "ai_summary": triage.summary,
-            "ai_reasoning": triage.reasoning,
-            "ai_model_used": triage.model_used,
-            "ai_tags": triage.tags,
-            "ai_suggested_assignee": _map_suggested_assignee(triage),
-            "ai_input_tokens": triage.input_tokens,
-            "ai_output_tokens": triage.output_tokens,
-            "language": triage.language,
-            "is_spam": triage.is_spam,
-            "spam_score": triage.spam_score,
-            "ai_confidence": triage.confidence,
-            "processing_status": Email.ProcessingStatus.COMPLETED,
-        },
-    )
-
-    # Save attachment metadata (clear old ones on update, re-create)
-    if email_msg.attachment_details:
-        if not created:
-            email_obj.attachments.all().delete()
-        for att in email_msg.attachment_details:
-            AttachmentMetadata.objects.create(
-                email=email_obj,
-                filename=att.get("filename", ""),
-                size_bytes=att.get("size", 0),
-                mime_type=att.get("mime_type", ""),
-                gmail_attachment_id=att.get("attachment_id", ""),
-            )
-
-    # Set SLA deadlines (non-critical -- failure should not crash pipeline)
-    try:
-        set_sla_deadlines(email_obj)
-    except Exception:
-        logger.exception("Failed to set SLA deadlines for email %s", email_obj.pk)
-
-    # Thread create/update (THRD-04)
-    try:
-        thread_id = email_msg.thread_id or email_msg.message_id
-        thread, thread_created = Thread.objects.get_or_create(
-            gmail_thread_id=thread_id,
-            defaults={"subject": email_msg.subject},
+    with transaction.atomic():
+        email_obj, created = Email.objects.update_or_create(
+            message_id=email_msg.message_id,
+            defaults={
+                "gmail_id": email_msg.message_id,
+                "gmail_thread_id": email_msg.thread_id,
+                "from_address": email_msg.sender_email,
+                "from_name": email_msg.sender_name,
+                "to_inbox": email_msg.inbox,
+                "subject": email_msg.subject,
+                "body": email_msg.body,
+                "body_html": email_msg.body_html,
+                "headers": email_msg.headers,
+                "received_at": email_msg.timestamp,
+                "gmail_link": email_msg.gmail_link,
+                # AI triage fields
+                "category": triage.category,
+                "priority": triage.priority,
+                "ai_summary": triage.summary,
+                "ai_reasoning": triage.reasoning,
+                "ai_model_used": triage.model_used,
+                "ai_tags": triage.tags,
+                "ai_suggested_assignee": _map_suggested_assignee(triage),
+                "ai_input_tokens": triage.input_tokens,
+                "ai_output_tokens": triage.output_tokens,
+                "language": triage.language,
+                "is_spam": triage.is_spam,
+                "spam_score": triage.spam_score,
+                "ai_confidence": triage.confidence,
+                "processing_status": Email.ProcessingStatus.COMPLETED,
+            },
         )
-        email_obj.thread = thread
-        email_obj.save(update_fields=["thread"])
 
-        # Activity log
-        if thread_created:
-            ActivityLog.objects.create(
-                thread=thread,
-                email=email_obj,
-                action=ActivityLog.Action.THREAD_CREATED,
-                detail=f"Thread created from {email_msg.inbox}",
+        # Save attachment metadata (clear old ones on update, re-create)
+        if email_msg.attachment_details:
+            if not created:
+                email_obj.attachments.all().delete()
+            for att in email_msg.attachment_details:
+                AttachmentMetadata.objects.create(
+                    email=email_obj,
+                    filename=att.get("filename", ""),
+                    size_bytes=att.get("size", 0),
+                    mime_type=att.get("mime_type", ""),
+                    gmail_attachment_id=att.get("attachment_id", ""),
+                )
+
+        # Set SLA deadlines (non-critical -- failure should not crash pipeline)
+        try:
+            set_sla_deadlines(email_obj)
+        except Exception:
+            logger.exception("Failed to set SLA deadlines for email %s", email_obj.pk)
+
+        # Thread create/update (THRD-04)
+        try:
+            thread_id = email_msg.thread_id or email_msg.message_id
+            thread, thread_created = Thread.objects.get_or_create(
+                gmail_thread_id=thread_id,
+                defaults={"subject": email_msg.subject},
             )
-        else:
-            ActivityLog.objects.create(
-                thread=thread,
-                email=email_obj,
-                action=ActivityLog.Action.NEW_EMAIL_RECEIVED,
-                detail=f"New message from {email_msg.sender_email}",
-            )
+            email_obj.thread = thread
+            email_obj.save(update_fields=["thread"])
 
-        # Create ThreadReadState(is_read=False) for all active users on new threads
-        if thread_created:
-            _create_unread_states_for_all_users(thread)
+            # Activity log
+            if thread_created:
+                ActivityLog.objects.create(
+                    thread=thread,
+                    email=email_obj,
+                    action=ActivityLog.Action.THREAD_CREATED,
+                    detail=f"Thread created from {email_msg.inbox}",
+                )
+            else:
+                ActivityLog.objects.create(
+                    thread=thread,
+                    email=email_obj,
+                    action=ActivityLog.Action.NEW_EMAIL_RECEIVED,
+                    detail=f"New message from {email_msg.sender_email}",
+                )
 
-        # Reopen logic: any non-NEW/non-REOPENED thread reopens on new message
-        is_reopen = False
-        if not thread_created and thread.status not in (
-            Thread.Status.NEW,
-            Thread.Status.REOPENED,
-        ):
-            old_status = thread.status
-            thread.status = Thread.Status.REOPENED
-            thread.save(update_fields=["status"])
-            is_reopen = True
-            ActivityLog.objects.create(
-                thread=thread,
-                email=email_obj,
-                action=ActivityLog.Action.REOPENED,
-                detail=f"Reopened by new message from {email_msg.sender_email}",
-                old_value=old_status,
-                new_value=Thread.Status.REOPENED,
-            )
-            # Mark all users as unread on reopen
-            _create_unread_states_for_all_users(thread)
+            # Create ThreadReadState(is_read=False) for all active users on new threads
+            if thread_created:
+                _create_unread_states_for_all_users(thread)
 
-        # Update denormalized preview fields
-        update_thread_preview(thread)
+            # Reopen logic: any non-NEW/non-REOPENED thread reopens on new message
+            is_reopen = False
+            if not thread_created and thread.status not in (
+                Thread.Status.NEW,
+                Thread.Status.REOPENED,
+            ):
+                old_status = thread.status
+                thread.status = Thread.Status.REOPENED
+                thread.save(update_fields=["status"])
+                is_reopen = True
+                ActivityLog.objects.create(
+                    thread=thread,
+                    email=email_obj,
+                    action=ActivityLog.Action.REOPENED,
+                    detail=f"Reopened by new message from {email_msg.sender_email}",
+                    old_value=old_status,
+                    new_value=Thread.Status.REOPENED,
+                )
+                # Mark all users as unread on reopen
+                _create_unread_states_for_all_users(thread)
 
-        # Attach metadata for notification routing
-        email_obj._thread_created = thread_created
-        email_obj._thread_reopened = is_reopen
+            # Update denormalized preview fields
+            update_thread_preview(thread)
 
-    except Exception:
-        logger.exception("Failed to handle thread for email %s", email_obj.pk)
-        email_obj._thread_created = True  # Default: treat as new thread
-        email_obj._thread_reopened = False
+            # Attach metadata for notification routing
+            email_obj._thread_created = thread_created
+            email_obj._thread_reopened = is_reopen
+
+        except Exception:
+            logger.exception("Failed to handle thread for email %s", email_obj.pk)
+            email_obj._thread_created = True  # Default: treat as new thread
+            email_obj._thread_reopened = False
 
     action = "Created" if created else "Updated"
     logger.info(f"{action} email {email_msg.message_id}: {triage.category}/{triage.priority}")
@@ -544,6 +545,20 @@ def process_poll_cycle(gmail_poller, ai_processor, chat_notifier, state_manager)
         if not new_emails:
             logger.debug("No new emails found")
             state_manager.reset_failures()
+            # Persist last_poll_epoch even on empty polls (keeps inspector countdown accurate)
+            try:
+                now_epoch = str(int(time.time()))
+                SystemConfig.objects.update_or_create(
+                    key="last_poll_epoch",
+                    defaults={
+                        "value": now_epoch,
+                        "value_type": SystemConfig.ValueType.INT,
+                        "description": "Epoch timestamp of last successful poll cycle (deploy safety)",
+                        "category": "scheduler",
+                    },
+                )
+            except Exception as cfg_err:
+                logger.warning(f"Failed to persist last_poll_epoch: {cfg_err}")
             _create_poll_log(
                 started_at=poll_started_at,
                 status="success",
@@ -657,6 +672,9 @@ def _create_poll_log(*, started_at, status, emails_found=0, emails_processed=0,
         logger.warning(f"Failed to create PollLog: {log_err}")
 
 
+RETRY_BATCH_SIZE = 10
+
+
 def retry_failed_emails(ai_processor, gmail_poller):
     """Retry emails with processing_status='failed' and retry_count < 3.
 
@@ -669,7 +687,7 @@ def retry_failed_emails(ai_processor, gmail_poller):
             processing_status=Email.ProcessingStatus.FAILED,
             retry_count__lt=3,
         )
-        .order_by("created_at")[:10]
+        .order_by("created_at")[:RETRY_BATCH_SIZE]
     )
 
     for email_obj in failed_emails:

--- a/apps/emails/services/reports.py
+++ b/apps/emails/services/reports.py
@@ -256,7 +256,7 @@ def get_team_data(start, end, **filters):
         # Calculate avg response for this user's ack actions
         total_minutes = 0
         count = 0
-        for act in ack_activities.select_related("thread"):
+        for act in ack_activities.select_related("thread", "email"):
             if act.thread and act.thread.created_at:
                 delta = act.created_at - act.thread.created_at
                 total_minutes += delta.total_seconds() / 60

--- a/apps/emails/services/state.py
+++ b/apps/emails/services/state.py
@@ -8,7 +8,7 @@ failure counter (harmless). No persistent state needed.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -42,11 +42,11 @@ class StateManager:
         """Return True if an EOD report hasn't been sent in the last 10 minutes."""
         if self._last_eod_time is None:
             return True
-        return (datetime.now() - self._last_eod_time).total_seconds() > 600
+        return (datetime.now(timezone.utc) - self._last_eod_time).total_seconds() > 600
 
     def record_eod_sent(self):
         """Record that an EOD report was just sent."""
-        self._last_eod_time = datetime.now()
+        self._last_eod_time = datetime.now(timezone.utc)
 
     # --- Config change detection ---
 

--- a/apps/emails/tests/test_pipeline.py
+++ b/apps/emails/tests/test_pipeline.py
@@ -882,3 +882,62 @@ class TestSchedulerCommand:
         signal_calls = [c[0][0] for c in mock_signal.call_args_list]
         assert signal.SIGTERM in signal_calls
         assert signal.SIGINT in signal_calls
+
+
+@pytest.mark.django_db
+class TestPollEpochOnEmptyPoll:
+    """Test that last_poll_epoch updates even when no new emails are found (Step 1b fix)."""
+
+    def test_empty_poll_updates_last_poll_epoch(self):
+        from apps.emails.services.pipeline import process_poll_cycle
+        from apps.core.models import SystemConfig
+
+        mock_poller = MagicMock()
+        mock_poller.poll_all.return_value = []  # No new emails
+
+        mock_ai = MagicMock()
+        mock_state = MagicMock()
+        mock_state.consecutive_failures = 0
+
+        with patch("apps.emails.services.pipeline.SystemConfig") as mock_config:
+            # Use real SystemConfig for epoch persistence, mock for other config reads
+            mock_config.get.side_effect = lambda key, default=None: {
+                "ai_triage_enabled": True,
+                "chat_notifications_enabled": False,
+                "monitored_inboxes": "info@vidarbhainfotech.com",
+                "max_consecutive_failures": 3,
+                "operating_mode": "dev",
+            }.get(key, default)
+            # Let update_or_create work on real DB
+            mock_config.objects = SystemConfig.objects
+            mock_config.ValueType = SystemConfig.ValueType
+
+            process_poll_cycle(mock_poller, mock_ai, None, mock_state)
+
+        # Verify last_poll_epoch was persisted
+        epoch_config = SystemConfig.objects.filter(key="last_poll_epoch").first()
+        assert epoch_config is not None
+        assert epoch_config.value != ""
+        assert int(epoch_config.value) > 0
+
+
+@pytest.mark.django_db
+class TestThreadListIsAdminFix:
+    """Test that admin viewing a team member's thread list doesn't crash (Step 1a fix)."""
+
+    def test_admin_views_member_threads_no_crash(self, admin_user, client):
+        """Admin viewing a numeric view (team member's threads) should not raise NameError."""
+        from conftest import create_thread
+        from apps.accounts.models import User
+
+        member = User.objects.create_user(
+            username="team_member_view",
+            password="testpass123",
+            email="tmv@vidarbhainfotech.com",
+            role=User.Role.MEMBER,
+        )
+        thread = create_thread(assigned_to=member)
+
+        client.force_login(admin_user)
+        response = client.get(f"/emails/?view={member.pk}")
+        assert response.status_code == 200

--- a/apps/emails/tests/test_state.py
+++ b/apps/emails/tests/test_state.py
@@ -1,6 +1,6 @@
 """Tests for StateManager circuit breaker and EOD dedup."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from apps.emails.services.state import StateManager
 
@@ -47,12 +47,12 @@ class TestCanSendEod:
 
     def test_false_within_10_minutes(self):
         sm = StateManager()
-        sm._last_eod_time = datetime.now() - timedelta(minutes=5)
+        sm._last_eod_time = datetime.now(timezone.utc) - timedelta(minutes=5)
         assert sm.can_send_eod() is False
 
     def test_true_after_10_minutes(self):
         sm = StateManager()
-        sm._last_eod_time = datetime.now() - timedelta(minutes=11)
+        sm._last_eod_time = datetime.now(timezone.utc) - timedelta(minutes=11)
         assert sm.can_send_eod() is True
 
 
@@ -62,7 +62,12 @@ class TestRecordEodSent:
         assert sm._last_eod_time is None
         sm.record_eod_sent()
         assert sm._last_eod_time is not None
-        assert (datetime.now() - sm._last_eod_time).total_seconds() < 2
+        assert (datetime.now(timezone.utc) - sm._last_eod_time).total_seconds() < 2
+
+    def test_timestamp_is_timezone_aware(self):
+        sm = StateManager()
+        sm.record_eod_sent()
+        assert sm._last_eod_time.tzinfo is not None
 
 
 class TestDetectConfigChanges:

--- a/apps/emails/views/pages.py
+++ b/apps/emails/views/pages.py
@@ -238,7 +238,7 @@ def thread_list(request):
         stat_base = stat_base.filter(status__in=["new", "acknowledged", "reopened"])
     elif view == "closed":
         stat_base = stat_base.filter(status__in=["closed", "irrelevant"])
-    elif view.isdigit() and is_admin:
+    elif view.isdigit() and can_assign:
         stat_base = stat_base.filter(assigned_to_id=int(view))
 
     view_stats = stat_base.aggregate(

--- a/apps/emails/views/threads.py
+++ b/apps/emails/views/threads.py
@@ -159,13 +159,16 @@ def reject_thread_suggestion(request, pk):
 @require_POST
 def viewer_heartbeat(request, pk):
     """Update viewer presence and return the viewer badge partial."""
-    ThreadViewer.objects.update_or_create(
-        thread_id=pk, user=request.user,
-        defaults={"last_seen": timezone.now()},
-    )
-    # Opportunistic cleanup of stale records
-    cutoff = timezone.now() - timedelta(seconds=30)
-    ThreadViewer.objects.filter(thread_id=pk, last_seen__lt=cutoff).delete()
+    from django.db import transaction
+
+    with transaction.atomic():
+        ThreadViewer.objects.update_or_create(
+            thread_id=pk, user=request.user,
+            defaults={"last_seen": timezone.now()},
+        )
+        # Opportunistic cleanup of stale records
+        cutoff = timezone.now() - timedelta(seconds=30)
+        ThreadViewer.objects.filter(thread_id=pk, last_seen__lt=cutoff).delete()
 
     active_viewers = get_active_viewers(pk, exclude_user_id=request.user.pk)
     html = render_to_string("emails/_viewer_badge.html", {"active_viewers": active_viewers}, request=request)
@@ -789,16 +792,14 @@ def mark_not_spam(request, pk):
 
             # Auto-whitelist if sender was blocked (SPAM-05)
             if was_blocked:
-                from django.db import IntegrityError
-                try:
-                    SpamWhitelist.objects.create(
-                        entry=sender,
-                        entry_type="email",
-                        added_by=request.user,
-                        reason="Auto-whitelisted: user marked not-spam on blocked sender",
-                    )
-                except IntegrityError:
-                    pass  # Already whitelisted
+                SpamWhitelist.objects.get_or_create(
+                    entry=sender,
+                    entry_type="email",
+                    defaults={
+                        "added_by": request.user,
+                        "reason": "Auto-whitelisted: user marked not-spam on blocked sender",
+                    },
+                )
 
                 SenderReputation.objects.filter(sender_address__iexact=sender).update(is_blocked=False)
                 toast_msg = "Marked as not spam and sender unblocked"

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -14,7 +14,7 @@ DEBUG = False
 # SECRET_KEY must be set in production -- crash on startup if missing
 SECRET_KEY = os.environ["SECRET_KEY"]
 
-ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")
+ALLOWED_HOSTS = [h.strip() for h in os.environ.get("ALLOWED_HOSTS", "").split(",") if h.strip()]
 
 # Database from DATABASE_URL (required in production)
 DATABASES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 # VIPL Email Agent v2 -- Production Dependencies
 django>=4.2,<4.3
-psycopg[binary]>=3.2
+psycopg[binary]>=3.2,<4.0
 gunicorn>=23.0
 whitenoise>=6.8
 dj-database-url>=2.3
 python-dotenv>=1.0
 
 # Phase 2: Email pipeline dependencies
-anthropic>=0.49
+anthropic>=0.49,<1.0
 google-api-python-client>=2.150
 google-auth>=2.35
 tenacity>=9.0
 APScheduler>=3.10,<4.0
-httpx>=0.27
+httpx>=0.27,<1.0
 pypdf>=5.0
 pytz>=2024.1
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -194,7 +194,7 @@
         .htmx-swapping { opacity: 0.5; transition: opacity 0.15s ease-out; }
         .htmx-request { opacity: 0.6; transition: opacity 0.2s; }
         .htmx-request button[type="submit"] { pointer-events: none; }
-        button[disabled] { opacity: 0.4; cursor: not-allowed; }
+        button[disabled] { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
 
         /* Progress bar */
         #htmx-progress { position: fixed; top: 0; left: 0; height: 2px; background: var(--vipl-primary); z-index: 9999; width: 0; transition: width 0.3s ease; pointer-events: none; }

--- a/templates/emails/_thread_detail.html
+++ b/templates/emails/_thread_detail.html
@@ -92,7 +92,7 @@
                         {% csrf_token %}
                         <button type="submit" hx-disabled-elt="this"
                                 class="p-1 rounded hover:bg-[var(--vipl-primary)]/10 text-[var(--vipl-primary)] transition-colors cursor-pointer"
-                                title="Accept suggestion">
+                                title="Accept suggestion" aria-label="Accept AI suggestion">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/>
                             </svg>
@@ -103,7 +103,7 @@
                         {% csrf_token %}
                         <button type="submit" hx-disabled-elt="this"
                                 class="p-1 rounded hover:bg-[var(--vipl-red)]/10 text-[var(--vipl-red)]/60 transition-colors cursor-pointer"
-                                title="Dismiss suggestion">
+                                title="Dismiss suggestion" aria-label="Reject AI suggestion">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                             </svg>

--- a/templates/emails/thread_list.html
+++ b/templates/emails/thread_list.html
@@ -405,6 +405,7 @@ document.addEventListener('scroll', closeContextMenu, true);
 
 var longPressTimer = null;
 function startLongPress(event, threadPk) {
+    if (!event.touches || !event.touches.length) return;
     longPressTimer = setTimeout(function() {
         var touch = event.touches[0];
         showContextMenu({ preventDefault: function(){}, stopPropagation: function(){},


### PR DESCRIPTION
## Summary

- **Critical fixes**: `NameError: is_admin` crash on admin thread list view, poll countdown stuck at "Due now" (empty polls not updating epoch), timezone-naive `StateManager` EOD dedup, missing `transaction.atomic()` in `save_email_to_db`
- **High-severity**: viewer heartbeat race condition, prompt injection risk in correction rules, touch safety guard for mobile long press, team workload error logging upgrade
- **Medium**: `ALLOWED_HOSTS` whitespace handling, `get_or_create` for auto-whitelist, N+1 query fix in reports team data, named constants for magic numbers, dependency upper bounds (`anthropic<1.0`, `httpx<1.0`, `psycopg<4.0`)
- **Minor/UX**: disabled button `pointer-events: none`, `aria-label` on accept/reject AI suggestion buttons

> **Note**: `deploy.yml` rollback safety changes excluded from this PR due to GitHub OAuth workflow scope limitation — will be applied separately.

## Test plan

- [ ] `pytest apps/emails/tests/test_pipeline.py::TestThreadListIsAdminFix -v` — admin views member thread list without crash
- [ ] `pytest apps/emails/tests/test_pipeline.py::TestPollEpochOnEmptyPoll -v` — empty polls update `last_poll_epoch`
- [ ] `pytest apps/emails/tests/test_state.py -v` — timezone-aware StateManager
- [ ] `pytest -v` — full test suite passes
- [ ] `docker compose build` — Docker image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)